### PR TITLE
Update Readme to reflect a new best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,17 @@ ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "192.168.0.12", "::1"] // Add IP 
 ````
 
 
-The easiest and least invasive way of configuring openhab to push state changes to the magic mirror server, is via a dedicated rules-file, e.g. `mirror.rules`:
+The easiest and least invasive way of configuring openhab to push state changes to the magic mirror server, is to add all items you want to update to a group gMagicMirrorItems and create the following rule:
 ````
-// define your magic mirror URL here; make sure that there is no trailing slash
-var String mirrorUrl = "http://mirror:8080/openhab"
+val String mirrorUrl = "http://<MAGIC_MIRROR_URL>:<MAGIC_MIRROR_PORT>/openhab"
 
-// whenever one of your items of interest changes, send a GET request to the magic mirror server
-rule "L_Living to mirror"          when Item L_Living         changed then sendHttpGetRequest(mirrorUrl + "?item=L_Living&state="          + L_Living.state)          end
-rule "Reed_Door to mirror"         when Item Reed_Door        changed then sendHttpGetRequest(mirrorUrl + "?item=Reed_Door&state="         + Reed_Door.state)         end
-rule "Temperature_Entry to mirror" when Item Temerature_Entry changed then sendHttpGetRequest(mirrorUrl + "?item=Temperature_Entry&state=" + Temperature_Entry.state) end
-// etc. this is always the same pattern, independent of the item type
+rule "send updates to MagicMirror"
+
+when
+	Member of gMagicMirrorItems changed
+then
+		var url = mirrorUrl + "?item=" + triggeringItem.name + "&state=" + triggeringItem.state
+		sendHttpGetRequest(url)
+		logInfo("MagicMirror","Sent to MM: "+ url)
+end
 ````


### PR DESCRIPTION
I found that early this year there has been a change in openhab that allows for a Member of trigger of a rule. This makes the process a lot cleaner (no more rule adaptations, just add the item to the correct group). I propose to change the readme to reflect this.